### PR TITLE
try bash

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,6 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+#
 # Run the Ibis tests. Two environment variables are considered:
 # - PYTEST_BACKENDS: Space-separated list of backends to run
+
+set -e
 
 TESTS_DIRS="ibis/tests ibis/backends/tests"
 for BACKEND in $PYTEST_BACKENDS; do

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -49,12 +49,20 @@ def _get_backends_to_test():
     """
     Get a list of `TestConf` classes of the backends to test.
 
-    The list of backends can be specified by theuse rwith the `PYTEST_BACKENDS`
-    environment variable, or otherwise all backends are being tested.
+    The list of backends can be specified by the user with the
+    `PYTEST_BACKENDS` environment variable.
+
+    - If the variable is undefined or empty, then no backends are returned
+    - Otherwise the variable must contain a space-separated list of backends to
+      test
+
     """
-    backends = os.environ.get('PYTEST_BACKENDS', '').split(' ')
-    if backends == ['']:
-        backends = _get_all_backends()
+    backends_raw = os.environ.get('PYTEST_BACKENDS')
+
+    if not backends_raw:
+        return []
+
+    backends = backends_raw.split()
 
     return [
         pytest.param(

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
             'postgres = ibis.backends.postgres',
             'mysql = ibis.backends.mysql',
             'clickhouse = ibis.backends.clickhouse',
-            'spark = ibis.backends.spark',
+            'spark = ibis.backends.pyspark',
             'pyspark = ibis.backends.pyspark',
             'dask = ibis.backends.dask',
         ]


### PR DESCRIPTION
- fix: allow an undefined PYTEST_BACKENDS variable to indicate no backends should be tested (#2942)
- fix: forward the spark entry point to pyspark (#2941)
- ci: windows
