### PR TITLE
rules refactor

### DIFF
--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -7,7 +7,6 @@ import ibis.expr.analysis as L
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-from ibis.expr.signature import Argument
 
 _map_interval_to_microseconds = {
     'W': 604800000000,
@@ -42,9 +41,7 @@ _cumulative_to_reduction = {
 }
 
 
-def _replace_interval_with_scalar(
-    expr: Union[ir.Expr, dt.Interval, float]
-) -> Union[ir.Expr, float, Argument]:
+def _replace_interval_with_scalar(expr: Union[ir.Expr, dt.Interval, float]):
     """
     Good old Depth-First Search to identify the Interval and IntervalValue
     components of the expression and return a comparable scalar expression.

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -162,8 +162,9 @@ def test_string_temporal_compare_between_datetimes(con, left, right):
 
 @pytest.mark.parametrize('container', [list, tuple, set])
 def test_field_in_literals(con, alltypes, translate, container):
-    foobar = container(['foo', 'bar', 'baz'])
-    expected = tuple(set(foobar))
+    values = {'foo', 'bar', 'baz'}
+    foobar = container(values)
+    expected = tuple(values)
 
     expr = alltypes.string_col.isin(foobar)
     assert translate(expr) == f"`string_col` IN {expected}"

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -48,20 +48,20 @@ FROM {0}.`functional_alltypes`"""
 
 
 def test_isin_notin_in_select(con, db, alltypes, translate):
-    values = ['foo', 'bar']
+    values = {'foo', 'bar'}
     filtered = alltypes[alltypes.string_col.isin(values)]
     result = ibis.clickhouse.compile(filtered)
     expected = """SELECT *
 FROM {}.`functional_alltypes`
 WHERE `string_col` IN {}"""
-    assert result == expected.format(db.name, tuple(set(values)))
+    assert result == expected.format(db.name, tuple(values))
 
     filtered = alltypes[alltypes.string_col.notin(values)]
     result = ibis.clickhouse.compile(filtered)
     expected = """SELECT *
 FROM {}.`functional_alltypes`
 WHERE `string_col` NOT IN {}"""
-    assert result == expected.format(db.name, tuple(set(values)))
+    assert result == expected.format(db.name, tuple(values))
 
 
 def test_head(alltypes):

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -752,7 +752,7 @@ class TestInNotIn(unittest.TestCase, ExprSQLTest):
         self.table = self.con.table('alltypes')
 
     def test_field_in_literals(self):
-        values = ['foo', 'bar', 'baz']
+        values = {'foo', 'bar', 'baz'}
         values_formatted = tuple(set(values))
         cases = [
             (self.table.g.isin(values), f"`g` IN {values_formatted}"),
@@ -777,8 +777,8 @@ class TestInNotIn(unittest.TestCase, ExprSQLTest):
         self._check_expr_cases(cases)
 
     def test_isin_notin_in_select(self):
-        values = ['foo', 'bar']
-        values_formatted = tuple(set(values))
+        values = {'foo', 'bar'}
+        values_formatted = tuple(values)
 
         filtered = self.table[self.table.g.isin(values)]
         result = ImpalaCompiler.to_sql(filtered)

--- a/ibis/backends/impala/udf.py
+++ b/ibis/backends/impala/udf.py
@@ -11,13 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import re
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
-import ibis.expr.signature as sig
 import ibis.udf.validate as v
 import ibis.util as util
 from ibis.backends.base.sql.registry import fixed_arity, sql_type_names
@@ -33,17 +33,16 @@ __all__ = [
 ]
 
 
-class Function:
+class Function(metaclass=abc.ABCMeta):
     def __init__(self, inputs, output, name):
         self.inputs = tuple(map(dt.dtype, inputs))
         self.output = dt.dtype(output)
-        self.name = name
-        self._klass = self._create_operation(name)
+        self.name = name or util.guid()
+        self._klass = self._create_operation_class()
 
-    def _create_operation(self, name):
-        class_name = self._get_class_name(name)
-        input_type, output_type = self._type_signature()
-        return _create_operation_class(class_name, input_type, output_type)
+    @abc.abstractmethod
+    def _create_operation_class(self):
+        pass
 
     def __repr__(self):
         klass = type(self).__name__
@@ -68,35 +67,22 @@ class Function:
 
 
 class ScalarFunction(Function):
-    def _get_class_name(self, name):
-        if name is None:
-            name = util.guid()
-        return f'UDF_{name}'
-
-    def _type_signature(self):
-        input_type = _ibis_signature(self.inputs)
-        output_type = rlz.shape_like('args', dt.dtype(self.output))
-        return input_type, output_type
+    def _create_operation_class(self):
+        fields = {
+            f'_{i}': rlz.value(dtype) for i, dtype in enumerate(self.inputs)
+        }
+        fields['output_type'] = rlz.shape_like('args', self.output)
+        return type(f"UDF_{self.name}", (ops.ValueOp,), fields)
 
 
 class AggregateFunction(Function):
-    def _create_operation(self, name):
-        klass = super()._create_operation(name)
-        klass._reduction = True
-        return klass
-
-    def _get_class_name(self, name):
-        if name is None:
-            name = util.guid()
-        return f'UDA_{name}'
-
-    def _type_signature(self):
-        def output_type(op):
-            return dt.dtype(self.output).scalar_type()
-
-        input_type = _ibis_signature(self.inputs)
-
-        return input_type, output_type
+    def _create_operation_class(self):
+        fields = {
+            f'_{i}': rlz.value(dtype) for i, dtype in enumerate(self.inputs)
+        }
+        fields['output_type'] = lambda op: self.output.scalar_type()
+        fields['_reduction'] = True
+        return type(f"UDA_{self.name}", (ops.ValueOp,), fields)
 
 
 class ImpalaFunction:
@@ -287,23 +273,6 @@ def aggregate_function(inputs, output, name=None):
     return AggregateFunction(inputs, output, name=name)
 
 
-def _ibis_signature(inputs):
-    if isinstance(inputs, sig.TypeSignature):
-        return inputs
-
-    arguments = [
-        (f'_{i}', sig.Argument(rlz.value(dtype)))
-        for i, dtype in enumerate(inputs)
-    ]
-    return sig.TypeSignature(arguments)
-
-
-def _create_operation_class(name, input_type, output_type):
-    func_dict = {'signature': input_type, 'output_type': output_type}
-    klass = type(name, (ops.ValueOp,), func_dict)
-    return klass
-
-
 def add_operation(op, func_name, db):
     """
     Registers the given operation within the Ibis SQL translation toolchain
@@ -319,7 +288,7 @@ def add_operation(op, func_name, db):
     # if op.input_type is rlz.listof:
     #     translator = comp.varargs(full_name)
     # else:
-    arity = len(op.signature)
+    arity = len(op.__signature__.parameters)
     translator = fixed_arity(full_name, arity)
 
     ImpalaExprTranslator._registry[op] = translator

--- a/ibis/backends/pandas/tests/test_datatypes.py
+++ b/ibis/backends/pandas/tests/test_datatypes.py
@@ -10,7 +10,6 @@ from pandas.api.types import CategoricalDtype, DatetimeTZDtype
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
-import ibis.expr.types as ir
 
 
 def test_no_infer_ambiguities():
@@ -137,15 +136,6 @@ def test_numpy_dtype(numpy_dtype, ibis_dtype):
 )
 def test_pandas_dtype(pandas_dtype, ibis_dtype):
     assert dt.dtype(pandas_dtype) == ibis_dtype
-
-
-def test_series_to_ibis_literal():
-    values = [1, 2, 3, 4]
-    s = pd.Series(values)
-
-    expr = ir.as_value_expr(s)
-    expected = ir.sequence(list(s))
-    assert expr.equals(expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -384,7 +384,7 @@ class ExprSimplifier:
                     lifted_root = self.lift(value_op.table)
 
             if can_lift and not block:
-                lifted_node = ops.TableColumn(node.name, lifted_root)
+                lifted_node = ops.TableColumn(lifted_root, node.name)
                 result = expr._factory(lifted_node, name=expr._name)
 
         return result

--- a/ibis/expr/analytics.py
+++ b/ibis/expr/analytics.py
@@ -30,8 +30,8 @@ class BucketLike(ops.ValueOp):
 
 
 class Bucket(BucketLike):
-    arg = Arg(rlz.noop)
-    buckets = Arg(rlz.noop)
+    arg = Arg(rlz.column(rlz.any))
+    buckets = Arg(rlz.list_of(rlz.scalar(rlz.any)))
     closed = Arg(rlz.isin({'left', 'right'}), default='left')
     close_extreme = Arg(bool, default=True)
     include_under = Arg(bool, default=False)
@@ -53,12 +53,12 @@ class Bucket(BucketLike):
 
 
 class Histogram(BucketLike):
-    arg = Arg(rlz.noop)
-    nbins = Arg(rlz.noop, default=None)
-    binwidth = Arg(rlz.noop, default=None)
-    base = Arg(rlz.noop, default=None)
+    arg = Arg(rlz.numeric)
+    nbins = Arg(int, default=None)
+    binwidth = Arg(rlz.scalar(rlz.numeric), default=None)
+    base = Arg(rlz.scalar(rlz.numeric), default=None)
     closed = Arg(rlz.isin({'left', 'right'}), default='left')
-    aux_hash = Arg(rlz.noop, default=None)
+    aux_hash = Arg(str, default=None)
 
     def _validate(self):
         if self.nbins is None:
@@ -74,8 +74,8 @@ class Histogram(BucketLike):
 
 class CategoryLabel(ops.ValueOp):
     arg = Arg(rlz.category)
-    labels = Arg(rlz.noop)
-    nulls = Arg(rlz.noop, default=None)
+    labels = Arg(rlz.list_of(rlz.instance_of(str)))
+    nulls = Arg(str, default=None)
     output_type = rlz.shape_like('arg', dt.string)
 
     def _validate(self):
@@ -83,7 +83,7 @@ class CategoryLabel(ops.ValueOp):
         if len(self.labels) != cardinality:
             raise ValueError(
                 'Number of labels must match number of '
-                'categories: {}'.format(cardinality)
+                f'categories: {cardinality}'
             )
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -3869,7 +3869,7 @@ def asof_join(left, right, predicates=(), by=(), tolerance=None):
     return ops.AsOfJoin(left, right, predicates, by, tolerance).to_expr()
 
 
-def cross_join(*tables):
+def cross_join(left, right, *rest, **kwargs):
     """
     Perform a cross join (cartesian product) amongst a list of tables, with
     optional set of prefixes to apply to overlapping column names
@@ -3934,7 +3934,12 @@ def cross_join(*tables):
           right:
             Table: ref_4
     """
-    op = ops.CrossJoin(*tables)
+    if 'prefixes' in kwargs:
+        raise NotImplementedError(
+            "`prefixes` keyword argument not implemented"
+        )
+    reducer = functools.partial(ir.TableExpr.cross_join, **kwargs)
+    op = ops.CrossJoin(left, functools.reduce(reducer, rest, right), [])
     return op.to_expr()
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1217,7 +1217,7 @@ def topk(arg, k, by=None):
     -------
     topk : TopK filter expression
     """
-    op = ops.TopK(arg, k, by=by)
+    op = ops.TopK(arg, k, by=by if by is not None else arg.count())
     return op.to_expr()
 
 
@@ -3869,7 +3869,7 @@ def asof_join(left, right, predicates=(), by=(), tolerance=None):
     return ops.AsOfJoin(left, right, predicates, by, tolerance).to_expr()
 
 
-def cross_join(*tables, **kwargs):
+def cross_join(*tables):
     """
     Perform a cross join (cartesian product) amongst a list of tables, with
     optional set of prefixes to apply to overlapping column names
@@ -3934,8 +3934,7 @@ def cross_join(*tables, **kwargs):
           right:
             Table: ref_4
     """
-    # TODO(phillipc): Implement prefix keyword argument
-    op = ops.CrossJoin(*tables, **kwargs)
+    op = ops.CrossJoin(*tables)
     return op.to_expr()
 
 
@@ -4048,7 +4047,7 @@ def _resolve_predicates(table, predicates):
     return resolved_predicates
 
 
-def aggregate(table, metrics=None, by=None, having=None, **kwds):
+def aggregate(table, metrics=None, by=None, having=None, **kwargs):
     """
     Aggregate a table with a given set of reductions, with grouping
     expressions, and post-aggregation filters.
@@ -4066,14 +4065,18 @@ def aggregate(table, metrics=None, by=None, having=None, **kwds):
     -------
     agg_expr : TableExpr
     """
-    if metrics is None:
-        metrics = []
+    metrics = [] if metrics is None else util.promote_list(metrics)
+    metrics.extend(
+        table._ensure_expr(expr).name(name)
+        for name, expr in sorted(kwargs.items(), key=operator.itemgetter(0))
+    )
 
-    for k, v in sorted(kwds.items()):
-        v = table._ensure_expr(v)
-        metrics.append(v.name(k))
-
-    op = table.op().aggregate(table, metrics, by=by, having=having)
+    op = table.op().aggregate(
+        table,
+        metrics,
+        by=util.promote_list(by if by is not None else []),
+        having=util.promote_list(having if having is not None else []),
+    )
     return op.to_expr()
 
 
@@ -4147,9 +4150,12 @@ def _table_sort_by(table, sort_exprs):
 
     Returns
     -------
-    sorted : TableExpr
+    TableExpr
     """
-    result = table.op().sort_by(table, sort_exprs)
+    result = table.op().sort_by(
+        table,
+        util.promote_list(sort_exprs if sort_exprs is not None else []),
+    )
     return result.to_expr()
 
 
@@ -4209,11 +4215,15 @@ def _table_difference(left: TableExpr, right: TableExpr):
 
 
 def _table_to_array(self):
-    """
-    Single column tables can be viewed as arrays.
-    """
-    op = ops.TableArrayView(self)
-    return op.to_expr()
+    """View a single column table as an array."""
+
+    schema = self.schema()
+    if len(schema) > 1:
+        raise com.ExpressionError(
+            'Table can only have a single column when viewed as array'
+        )
+
+    return ops.TableArrayView(self).to_expr()
 
 
 def _table_materialize(table):

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -14,6 +14,7 @@ import toolz
 import ibis.common.exceptions as com
 import ibis.expr.analysis as _L
 import ibis.expr.analytics as _analytics
+import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
@@ -99,10 +100,8 @@ from ibis.expr.types import (  # noqa
     TimeValue,
     ValueExpr,
     array,
-    as_value_expr,
     literal,
     null,
-    sequence,
 )
 from ibis.expr.window import (
     cumulative_window,
@@ -260,6 +259,22 @@ def param(type):
     >>> expr = t.filter(predicates).value.sum()
     """
     return ops.ScalarParameter(dt.dtype(type)).to_expr()
+
+
+def sequence(values):
+    """
+    Wrap a list of Python values as an Ibis sequence type
+
+    Parameters
+    ----------
+    values : list
+      Should all be None or the same type
+
+    Returns
+    -------
+    seq : Sequence
+    """
+    return ops.ValueList(values).to_expr()
 
 
 def schema(pairs=None, names=None, types=None):
@@ -507,7 +522,7 @@ def case():
     -------
     case : CaseBuilder
     """
-    return ops.SearchedCaseBuilder()
+    return bl.SearchedCaseBuilder()
 
 
 def now():
@@ -636,7 +651,7 @@ def arbitrary(arg, where=None, how=None):
 def _binop_expr(name, klass):
     def f(self, other):
         try:
-            other = as_value_expr(other)
+            other = rlz.any(other)
             op = klass(self, other)
             return op.to_expr()
         except (com.IbisTypeError, NotImplementedError):
@@ -650,7 +665,7 @@ def _binop_expr(name, klass):
 def _rbinop_expr(name, klass):
     # For reflexive binary ops, like radd, etc.
     def f(self, other):
-        other = as_value_expr(other)
+        other = rlz.any(other)
         op = klass(other, self)
         return op.to_expr()
 
@@ -660,7 +675,7 @@ def _rbinop_expr(name, klass):
 
 def _boolean_binary_op(name, klass):
     def f(self, other):
-        other = as_value_expr(other)
+        other = rlz.any(other)
 
         if not isinstance(other, ir.BooleanValue):
             raise TypeError(other)
@@ -683,7 +698,7 @@ def _boolean_unary_op(name, klass):
 
 def _boolean_binary_rop(name, klass):
     def f(self, other):
-        other = as_value_expr(other)
+        other = rlz.any(other)
 
         if not isinstance(other, ir.BooleanValue):
             raise TypeError(other)
@@ -965,9 +980,7 @@ def between(arg, lower, upper):
     -------
     is_between : BooleanValue
     """
-    lower = as_value_expr(lower)
-    upper = as_value_expr(upper)
-
+    lower, upper = rlz.any(lower), rlz.any(upper)
     op = ops.Between(arg, lower, upper)
     return op.to_expr()
 
@@ -1097,7 +1110,7 @@ def _case(arg):
         Literal[string]
           null or (not a and not b)
     """
-    return ops.SimpleCaseBuilder(arg)
+    return bl.SimpleCaseBuilder(arg)
 
 
 def cases(arg, case_result_pairs, default=None):
@@ -2650,7 +2663,7 @@ def ifelse(arg, true_expr, false_expr):
     # Result will be the result of promotion of true/false exprs. These
     # might be conflicting types; same type resolution as case expressions
     # must be used.
-    case = ops.SearchedCaseBuilder()
+    case = bl.SearchedCaseBuilder()
     return case.when(arg, true_expr).else_(false_expr).end()
 
 
@@ -3491,7 +3504,7 @@ def _timestamp_date(arg):
 
 
 def _timestamp_sub(left, right):
-    right = as_value_expr(right)
+    right = rlz.any(right)
 
     if isinstance(right, ir.TimestampValue):
         op = ops.TimestampDiff(left, right)
@@ -3731,7 +3744,7 @@ def _time_truncate(arg, unit):
 
 
 def _time_sub(left, right):
-    right = as_value_expr(right)
+    right = rlz.any(right)
 
     if isinstance(right, ir.TimeValue):
         op = ops.TimeDiff(left, right)
@@ -4278,12 +4291,12 @@ def mutate(
 
     """
     exprs = [] if exprs is None else util.promote_list(exprs)
-    exprs.extend(
-        (expr(table) if util.is_function(expr) else as_value_expr(expr)).name(
-            name
-        )
-        for name, expr in sorted(mutations.items(), key=operator.itemgetter(0))
-    )
+    for name, expr in sorted(mutations.items(), key=operator.itemgetter(0)):
+        if util.is_function(expr):
+            value = expr(table)
+        else:
+            value = rlz.any(expr)
+        exprs.append(value.name(name))
 
     mutation_exprs = _L.get_mutation_exprs(exprs, table)
     return table.projection(mutation_exprs)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4223,9 +4223,9 @@ def _table_to_array(self):
     """View a single column table as an array."""
 
     schema = self.schema()
-    if len(schema) > 1:
+    if len(schema) != 1:
         raise com.ExpressionError(
-            'Table can only have a single column when viewed as array'
+            'Table must have exactly one column when viewed as array'
         )
 
     return ops.TableArrayView(self).to_expr()

--- a/ibis/expr/builders.py
+++ b/ibis/expr/builders.py
@@ -1,0 +1,128 @@
+import ibis.expr.operations as ops
+import ibis.expr.rules as rlz
+import ibis.expr.types as ir
+
+
+class TypedCaseBuilder:
+    __slots__ = ()
+
+    def type(self):
+        return rlz.highest_precedence_dtype(self.results)
+
+    def else_(self, result_expr):
+        """
+        Specify
+
+        Returns
+        -------
+        builder : CaseBuilder
+        """
+        kwargs = {
+            slot: getattr(self, slot)
+            for slot in self.__slots__
+            if slot != 'default'
+        }
+
+        result_expr = rlz.any(result_expr)
+        kwargs['default'] = result_expr
+        # Maintain immutability
+        return type(self)(**kwargs)
+
+    def end(self):
+        default = self.default
+        if default is None:
+            default = ir.null().cast(self.type())
+
+        args = [
+            getattr(self, slot) for slot in self.__slots__ if slot != 'default'
+        ]
+        args.append(default)
+        op = self.__class__.case_op(*args)
+        return op.to_expr()
+
+
+class SimpleCaseBuilder(TypedCaseBuilder):
+    __slots__ = 'base', 'cases', 'results', 'default'
+
+    case_op = ops.SimpleCase
+
+    def __init__(self, base, cases=None, results=None, default=None):
+        self.base = base
+        self.cases = list(cases if cases is not None else [])
+        self.results = list(results if results is not None else [])
+        self.default = default
+
+    def when(self, case_expr, result_expr):
+        """
+        Add a new case-result pair.
+
+        Parameters
+        ----------
+        case : Expr
+          Expression to equality-compare with base expression. Must be
+          comparable with the base.
+        result : Expr
+          Value when the case predicate evaluates to true.
+
+        Returns
+        -------
+        builder : CaseBuilder
+        """
+        case_expr = rlz.any(case_expr)
+        result_expr = rlz.any(result_expr)
+
+        if not rlz.comparable(self.base, case_expr):
+            raise TypeError(
+                'Base expression and passed case are not ' 'comparable'
+            )
+
+        cases = list(self.cases)
+        cases.append(case_expr)
+
+        results = list(self.results)
+        results.append(result_expr)
+
+        # Maintain immutability
+        return type(self)(self.base, cases, results, self.default)
+
+
+class SearchedCaseBuilder(TypedCaseBuilder):
+    __slots__ = 'cases', 'results', 'default'
+
+    case_op = ops.SearchedCase
+
+    def __init__(self, cases=None, results=None, default=None):
+        self.cases = list(cases if cases is not None else [])
+        self.results = list(results if results is not None else [])
+        self.default = default
+
+    def when(self, case_expr, result_expr):
+        """
+        Add a new case-result pair.
+
+        Parameters
+        ----------
+        case : Expr
+          Expression to equality-compare with base expression. Must be
+          comparable with the base.
+        result : Expr
+          Value when the case predicate evaluates to true.
+
+        Returns
+        -------
+        builder : CaseBuilder
+        """
+        case_expr = rlz.any(case_expr)
+        result_expr = rlz.any(result_expr)
+
+        if not isinstance(case_expr, ir.BooleanValue):
+            raise TypeError(case_expr)
+
+        cases = list(self.cases)
+        cases.append(case_expr)
+
+        results = list(self.results)
+        results.append(result_expr)
+
+        # Maintain immutability
+        return type(self)(cases, results, self.default)

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -231,12 +231,7 @@ class ExprFormatter:
             for arg in op.flat_args():
                 visit(arg)
         else:
-            signature = op.signature
-            arg_name_pairs = (
-                (arg, name)
-                for arg, name in zip(op.args, arg_names)
-                if signature[name].show
-            )
+            arg_name_pairs = zip(op.args, arg_names)
             for arg, name in arg_name_pairs:
                 if name == 'arg' and isinstance(op, ops.ValueOp):
                     # don't display first argument's name in repr

--- a/ibis/expr/groupby.py
+++ b/ibis/expr/groupby.py
@@ -242,7 +242,7 @@ class GroupedTableExpr:
             sorts = w.order_by + self._order_by
             preceding, following = w.preceding, w.following
 
-        sorts = [ops.to_sort_key(self.table, k) for k in sorts]
+        sorts = [ops.to_sort_key(k, table=self.table) for k in sorts]
 
         groups = _resolve_exprs(self.table, groups)
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -906,7 +906,7 @@ class Reduction(ValueOp):
 
 
 class Count(Reduction):
-    arg = Arg((ir.ColumnExpr, ir.TableExpr))
+    arg = Arg(rlz.one_of((rlz.column(rlz.any), rlz.table)))
     where = Arg(rlz.boolean, default=None)
 
     def output_type(self):
@@ -1830,7 +1830,7 @@ class Selection(TableNode, HasSchema):
         rlz.list_of(
             rlz.one_of(
                 (
-                    rlz.instance_of(ir.TableExpr),
+                    rlz.table,
                     rlz.column_from("table"),
                     rlz.function_of("table"),
                     rlz.any,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1758,13 +1758,13 @@ def to_sort_key(key, *, table=None):
 class SortKey(Node):
     expr = Arg(rlz.column(rlz.any))
     ascending = Arg(
-        rlz.one_of(
-            (
-                rlz.literal(True),
-                rlz.literal(False),
-                rlz.enum_mapping(rlz.literal(1), to=True),
-                rlz.enum_mapping(rlz.literal(0), to=False),
-            )
+        rlz.map_to(
+            {
+                True: True,
+                False: False,
+                1: True,
+                0: False,
+            },
         ),
         default=True,
     )
@@ -1856,26 +1856,17 @@ class Selection(TableNode, HasSchema):
                                 rlz.any,
                             )
                         ),
-                        rlz.one_of(
-                            (
-                                rlz.literal(True),
-                                rlz.literal(False),
-                                rlz.enum_mapping(
-                                    rlz.literal("desc"),
-                                    to=False,
-                                ),
-                                rlz.enum_mapping(
-                                    rlz.literal("descending"),
-                                    to=False,
-                                ),
-                                rlz.enum_mapping(rlz.literal("asc"), to=True),
-                                rlz.enum_mapping(
-                                    rlz.literal("ascending"),
-                                    to=True,
-                                ),
-                                rlz.enum_mapping(rlz.literal(1), to=True),
-                                rlz.enum_mapping(rlz.literal(0), to=False),
-                            )
+                        rlz.map_to(
+                            {
+                                True: True,
+                                False: False,
+                                "desc": False,
+                                "descending": False,
+                                "asc": True,
+                                "ascending": True,
+                                1: True,
+                                0: False,
+                            }
                         ),
                     ),
                 )
@@ -2134,26 +2125,17 @@ class Aggregation(TableNode, HasSchema):
                                 rlz.any,
                             )
                         ),
-                        rlz.one_of(
-                            (
-                                rlz.literal(True),
-                                rlz.literal(False),
-                                rlz.enum_mapping(
-                                    rlz.literal("desc"),
-                                    to=False,
-                                ),
-                                rlz.enum_mapping(
-                                    rlz.literal("descending"),
-                                    to=False,
-                                ),
-                                rlz.enum_mapping(rlz.literal("asc"), to=True),
-                                rlz.enum_mapping(
-                                    rlz.literal("ascending"),
-                                    to=True,
-                                ),
-                                rlz.enum_mapping(rlz.literal(1), to=True),
-                                rlz.enum_mapping(rlz.literal(0), to=False),
-                            )
+                        rlz.map_to(
+                            {
+                                True: True,
+                                False: False,
+                                "desc": False,
+                                "descending": False,
+                                "asc": True,
+                                "ascending": True,
+                                1: True,
+                                0: False,
+                            }
                         ),
                     ),
                 )

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -257,7 +257,23 @@ class TableColumn(ValueOp):
     """Selects a column from a `TableExpr`."""
 
     table = Arg(rlz.table)
-    name = Arg(rlz.column_name_from("table"))
+    name = Arg(rlz.instance_of((str, int)))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        name = self.name
+        table = self.table
+
+        schema = table.schema()
+
+        if isinstance(name, int):
+            self.name = name = schema.name_at_position(name)
+
+        if name not in schema:
+            raise com.IbisTypeError(
+                f"value {name!r} is not a field in {table.columns}"
+            )
 
     def parent(self):
         return self.table

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1599,9 +1599,7 @@ class LeftAntiJoin(Join):
 
 
 class CrossJoin(Join):
-    def __init__(self, left, right, *rest):
-        right = functools.reduce(ir.TableExpr.cross_join, rest, right)
-        super().__init__(left, right, [])
+    pass
 
 
 class MaterializedJoin(TableNode, HasSchema):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2099,7 +2099,7 @@ class Aggregation(TableNode, HasSchema):
                 (
                     rlz.function_of("table"),
                     rlz.column_from("table"),
-                    rlz.any,
+                    rlz.column(rlz.any),
                 )
             )
         ),

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1834,7 +1834,7 @@ class Selection(TableNode, HasSchema):
                     rlz.column_from("table"),
                     rlz.function_of("table"),
                     rlz.any,
-                    rlz.named_literal_expression,
+                    rlz.named_literal,
                 )
             )
         ),
@@ -2077,7 +2077,7 @@ class Aggregation(TableNode, HasSchema):
                     rlz.reduction,
                     rlz.scalar(rlz.any),
                     rlz.expr_list_of(rlz.scalar(rlz.any)),
-                    rlz.named_literal_expression,
+                    rlz.named_literal,
                 )
             ),
             flatten=True,

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -1,4 +1,3 @@
-import collections
 import enum
 import functools
 from contextlib import suppress
@@ -148,16 +147,26 @@ def member_of(obj, arg):
 
 @validator
 def list_of(inner, arg, min_length=0):
-    if isinstance(arg, str) or not isinstance(
-        arg, (collections.abc.Sequence, ir.ListExpr)
-    ):
+    if not util.is_iterable(arg):
         raise com.IbisTypeError('Argument must be a sequence')
 
     if len(arg) < min_length:
         raise com.IbisTypeError(
             f'Arg must have at least {min_length} number of elements'
         )
-    return ir.sequence(list(map(inner, arg)))
+    return list(map(inner, arg))
+
+
+@validator
+def value_list_of(inner, arg, min_length=0):
+    # TODO(kszucs): would be nice to remove ops.ValueList
+    # the main blocker is that some of the backends execution
+    # model depends on the wrapper operation, for example
+    # the dispatcher in pandas requires operation objects
+    import ibis.expr.operations as ops
+
+    values = list_of(inner, arg, min_length=min_length)
+    return ops.ValueList(values).to_expr()
 
 
 @validator

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -157,15 +157,6 @@ def member_of(obj, arg, **kwargs):
     return getattr(obj, arg)
 
 
-def _flatten(iterable):
-    """Recursively flatten the iterable `iterable`."""
-    for item in iterable:
-        if util.is_iterable(item):
-            yield from _flatten(item)
-        else:
-            yield item
-
-
 @validator
 def container_of(inner, arg, *, type, min_length=0, flatten=False, **kwargs):
     if not util.is_iterable(arg):
@@ -175,7 +166,7 @@ def container_of(inner, arg, *, type, min_length=0, flatten=False, **kwargs):
         raise com.IbisTypeError(
             f'Arg must have at least {min_length} number of elements'
         )
-    flatten_func = _flatten if flatten else identity
+    flatten_func = util.flatten_iterable if flatten else identity
     return type(flatten_func(inner(item, **kwargs) for item in arg))
 
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -514,7 +514,7 @@ def is_computable_input(value, **kwargs):
 
 
 @validator
-def named_literal_expression(value, **kwargs):
+def named_literal(value, **kwargs):
     import ibis.expr.operations as ops
 
     if not isinstance(value, ir.ScalarExpr):

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -439,26 +439,6 @@ def column_from(name, column, *, this):
 
 
 @validator
-def column_name_from(name, column, *, this):
-    if not isinstance(column, (str, int)):
-        raise com.IbisTypeError(
-            f"value must be an int or str, got {type(column).__name__}"
-        )
-
-    table = getattr(this, name)
-
-    schema = table.schema()
-    if isinstance(column, int):
-        column = schema.name_at_position(column)
-
-    if column not in table.schema():
-        raise com.IbisTypeError(
-            f"value {column!r} is not a field in {table.columns}"
-        )
-    return column
-
-
-@validator
 def function_of(
     argument,
     fn,

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -137,9 +137,8 @@ def isin(values, arg, **kwargs):
 
 
 @validator
-def enum_mapping(inner, variant, to, **kwargs):
-    inner(variant, **kwargs)
-    return to
+def map_to(mapping, variant, **kwargs):
+    return mapping[variant]
 
 
 @validator
@@ -486,7 +485,7 @@ def non_negative_integer(arg, **kwargs):
 
 
 @validator
-def literal(value, arg, **kwargs):
+def python_literal(value, arg, **kwargs):
     if (
         not isinstance(arg, type(value))
         or not isinstance(value, type(arg))

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -518,9 +518,9 @@ def is_computable_input(value, **kwargs):
 def named_literal_expression(value, **kwargs):
     import ibis.expr.operations as ops
 
-    if not isinstance(value, ir.Expr):
+    if not isinstance(value, ir.ScalarExpr):
         raise com.IbisTypeError(
-            "`value` must be an ibis expression; "
+            "`value` must be a scalar expression; "
             f"got value of type {type(value).__name__}"
         )
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -196,36 +196,11 @@ def value_list_of(inner, arg, **kwargs):
 
 
 @validator
-def sort_key(key, *, from_=None, this, **kwargs):
+def sort_key(key, *, from_=None, this):
     import ibis.expr.operations as ops
 
-    if isinstance(key, ir.SortExpr):
-        return key
-
-    if isinstance(key, (tuple, list)):
-        key, sort_order = key
-    else:
-        sort_order = True
-
-    if not isinstance(key, ir.Expr):
-        if from_ is not None:
-            table = getattr(this, from_)
-            key = table._ensure_expr(key)
-            if isinstance(key, (ir.SortExpr, ops.DeferredSortKey)):
-                return ops.to_sort_key(table, key)
-        else:
-            raise ValueError(
-                "`key` is not an expression, "
-                "but no `from_` argument was provided"
-            )
-
-    if isinstance(sort_order, str):
-        if sort_order.lower() in ('desc', 'descending'):
-            sort_order = False
-        elif not isinstance(sort_order, bool):
-            sort_order = bool(sort_order)
-
-    return ops.SortKey(key, ascending=sort_order).to_expr()
+    table = getattr(this, from_) if from_ is not None else None
+    return ops.to_sort_key(key, table=table)
 
 
 @validator

--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import typing
 
@@ -34,7 +35,7 @@ class Optional(Validator):
 
     def __init__(self, validator, default=None):
         self.validator = validator
-        self.default = default
+        self.default = copy.deepcopy(default)
 
     def __call__(self, arg, **kwargs):
         if arg is None:

--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -2,7 +2,7 @@ import inspect
 import typing
 
 import ibis.expr.rules as rlz
-import ibis.util as util
+from ibis import util
 
 try:
     from cytoolz import unique

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -318,6 +318,9 @@ class ExprList(Expr):
     def _type_display(self):
         return ', '.join(expr._type_display() for expr in self.exprs())
 
+    def __iter__(self):
+        return iter(self.exprs())
+
     def exprs(self):
         return self.op().exprs
 
@@ -605,7 +608,7 @@ class TableExpr(Expr):
         """
         import ibis.expr.operations as ops
 
-        ref = ops.TableColumn(name, self)
+        ref = ops.TableColumn(self, name)
         return ref.to_expr()
 
     @property

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1290,38 +1290,6 @@ def literal(value, type=None):
         return ops.Literal(value, dtype=dtype).to_expr()
 
 
-def sequence(values):
-    """
-    Wrap a list of Python values as an Ibis sequence type
-
-    Parameters
-    ----------
-    values : list
-      Should all be None or the same type
-
-    Returns
-    -------
-    seq : Sequence
-    """
-    import ibis.expr.operations as ops
-
-    return ops.ValueList(values).to_expr()
-
-
-def as_value_expr(val):
-    import pandas as pd
-
-    if not isinstance(val, Expr):
-        if isinstance(val, (tuple, list)):
-            val = sequence(val)
-        elif isinstance(val, pd.Series):
-            val = sequence(list(val))
-        else:
-            val = literal(val)
-
-    return val
-
-
 def array(values):
     """Create an array expression.
 

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -97,9 +97,8 @@ def to_graph(expr, node_attr=None, edge_attr=None):
             vhash = str(hash(vkey))
             g.node(vhash, label=vlabel)
 
-            node = e.op()
-            args = node.args
-            for arg, name in zip(args, node.signature.names()):
+            op = e.op()
+            for name, arg in zip(op.argnames, op.args):
                 if isinstance(arg, ir.Expr):
                     u = arg, name
                     ukey = arg._key, name

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 
 import ibis.common.exceptions as com
-import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
 
@@ -102,6 +101,8 @@ class Window:
         max_lookback=None,
         how='rows',
     ):
+        import ibis.expr.operations as ops
+
         if group_by is None:
             group_by = []
 
@@ -228,6 +229,8 @@ class Window:
                 )
 
     def bind(self, table):
+        import ibis.expr.operations as ops
+
         # Internal API, ensure that any unresolved expr references (as strings,
         # say) are bound to the table being windowed
         groups = table._resolve(self._group_by)
@@ -276,6 +279,8 @@ class Window:
         return self._replace(order_by=new_sorts)
 
     def equals(self, other, cache=None):
+        import ibis.expr.operations as ops
+
         if cache is None:
             cache = {}
 
@@ -475,6 +480,8 @@ def trailing_range_window(preceding, order_by, group_by=None):
 
 
 def propagate_down_window(expr, window):
+    import ibis.expr.operations as ops
+
     op = expr.op()
 
     clean_args = []

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -234,7 +234,7 @@ class Window:
         # Internal API, ensure that any unresolved expr references (as strings,
         # say) are bound to the table being windowed
         groups = table._resolve(self._group_by)
-        sorts = [ops.to_sort_key(table, k) for k in self._order_by]
+        sorts = [ops.to_sort_key(k, table=table) for k in self._order_by]
         return self._replace(group_by=groups, order_by=sorts)
 
     def combine(self, window):

--- a/ibis/tests/expr/conftest.py
+++ b/ibis/tests/expr/conftest.py
@@ -111,6 +111,8 @@ def pytest_pyfunc_call(pyfuncitem):
         NotImplementedError,
     ) as e:
         markers = list(pyfuncitem.iter_markers(name="xfail_unsupported"))
+        if not markers:
+            raise
         assert (
             len(markers) == 1
         ), "More than one xfail_unsupported marker found on test {}".format(

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -1,7 +1,5 @@
 import ibis
 from ibis.expr.format import ExprFormatter
-from ibis.expr.operations import Node
-from ibis.expr.signature import Argument as Arg
 from ibis.expr.types import Expr
 
 
@@ -224,28 +222,6 @@ def test_scalar_parameter_formatting():
 
     value = ibis.param('int64').name('my_param')
     assert str(value) == 'my_param = ScalarParameter[int64]'
-
-
-def test_repring_does_not_show_with_option():
-    class CustomExpr(Expr):
-        pass
-
-    class CustomOp(Node):
-        first_arg = Arg(int, show=False)
-        second_arg = Arg(float)
-
-        def output_type(self):
-            return CustomExpr
-
-    op = CustomOp(1, 2.0)
-    expr = op.to_expr()
-
-    result = repr(expr)
-    expected = """\
-CustomOp[CustomExpr]
-  second_arg:
-    2.0"""
-    assert result == expected
 
 
 def test_same_column_multiple_aliases():

--- a/ibis/tests/expr/test_signature.py
+++ b/ibis/tests/expr/test_signature.py
@@ -3,6 +3,7 @@ from inspect import Signature
 import pytest
 from toolz import identity
 
+import ibis.expr.rules as rlz
 from ibis.common.exceptions import IbisTypeError
 from ibis.expr.signature import (
     Annotable,
@@ -216,3 +217,13 @@ def test_slots_are_inherited_and_overridable():
     assert StringOp.__slots__ == ('_cache', 'arg')
     assert StringSplit.__slots__ == ('_cache', 'arg', 'sep')
     assert StringJoin.__slots__ == ('_memoize', 'arg', 'sep')
+
+
+def test_copy_default():
+    default = []
+
+    class Op(Annotable):
+        arg = rlz.optional(rlz.instance_of(list), default=default)
+
+    op = Op()
+    assert op.arg is not default

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -34,8 +34,8 @@ def test_null():
     assert_equal(expr, expr2)
 
     assert expr is expr2
-    assert expr.type() is dt.null
-    assert expr2.type() is dt.null
+    assert expr.type().equals(dt.null)
+    assert expr2.type().equals(dt.null)
 
 
 @pytest.mark.xfail(

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -234,7 +234,7 @@ def test_literal_array():
 
 def test_mixed_arity(table):
     what = ["bar", table.g, "foo"]
-    expr = api.as_value_expr(what)
+    expr = api.sequence(what)
 
     values = expr.op().values
     assert isinstance(values[1], ir.StringColumn)

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -94,7 +94,7 @@ def test_join(how):
 def test_sort_by():
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('c')
+        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('b')
     )
     graph = viz.to_graph(expr)
     assert key(expr) in graph.source
@@ -107,7 +107,7 @@ def test_sort_by():
 def test_optional_graphviz_repr():
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('c')
+        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('b')
     )
 
     # default behavior

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -1710,8 +1710,8 @@ FROM t0
             'airlines',
         )
 
-        dests = ['ORD', 'JFK', 'SFO']
-        dests_formatted = repr(tuple(set(dests)))
+        dests = {'ORD', 'JFK', 'SFO'}
+        dests_formatted = repr(tuple(dests))
         delay_filter = airlines.dest.topk(10, by=airlines.arrdelay.mean())
         t = airlines[airlines.dest.isin(dests)]
         expr = t[delay_filter].group_by('origin').size()

--- a/ibis/tests/test_util.py
+++ b/ibis/tests/test_util.py
@@ -18,14 +18,14 @@ from ibis import util
         ([[4, [3, [2, [1]]]]], [4, 3, 2, 1]),
         ([[[[4], 3], 2], 1], [4, 3, 2, 1]),
         ([[[[1], 2], 3], 4], [1, 2, 3, 4]),
-        ([{(1,), frozenset({(2,)})}], [1, 2]),
+        ([{(1,), frozenset({(2,)})}], {1, 2}),
         ({(1, (2,)): None, "a": None}, [1, 2, "a"]),
         (([x] for x in range(5)), list(range(5))),
         ({(1, (2, frozenset({(3,)})))}, [1, 2, 3]),
     ],
 )
 def test_flatten(case, expected):
-    assert list(util.flatten_iterable(case)) == expected
+    assert type(expected)(util.flatten_iterable(case)) == expected
 
 
 @pytest.mark.parametrize("case", [1, "abc", b"abc", 2.0, object()])

--- a/ibis/tests/test_util.py
+++ b/ibis/tests/test_util.py
@@ -1,0 +1,36 @@
+"""Test ibis.util utilities."""
+
+import pytest
+
+from ibis import util
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ([], []),
+        ([1], [1]),
+        ([1, 2], [1, 2]),
+        ([[]], []),
+        ([[1]], [1]),
+        ([[1, 2]], [1, 2]),
+        ([[1, [2, [3, [4]]]]], [1, 2, 3, 4]),
+        ([[4, [3, [2, [1]]]]], [4, 3, 2, 1]),
+        ([[[[4], 3], 2], 1], [4, 3, 2, 1]),
+        ([[[[1], 2], 3], 4], [1, 2, 3, 4]),
+        ([{(1,), frozenset({(2,)})}], [1, 2]),
+        ({(1, (2,)): None, "a": None}, [1, 2, "a"]),
+        (([x] for x in range(5)), list(range(5))),
+        ({(1, (2, frozenset({(3,)})))}, [1, 2, 3]),
+    ],
+)
+def test_flatten(case, expected):
+    assert list(util.flatten_iterable(case)) == expected
+
+
+@pytest.mark.parametrize("case", [1, "abc", b"abc", 2.0, object()])
+def test_flatten_invalid_input(case):
+    flat = util.flatten_iterable(case)
+
+    with pytest.raises(TypeError):
+        list(flat)

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -343,3 +343,15 @@ def consume(iterator: Iterator[T], n: Optional[int] = None) -> None:
     else:
         # advance to the empty slice starting at position n
         next(itertools.islice(iterator, n, n), None)
+
+
+def flatten_iterable(iterable):
+    """Recursively flatten the iterable `iterable`."""
+    if not is_iterable(iterable):
+        raise TypeError("flatten is only defined for non-str iterables")
+
+    for item in iterable:
+        if is_iterable(item):
+            yield from flatten_iterable(item)
+        else:
+            yield item

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ markers = [
 [tool.black]
 line_length = 79
 skip_string_normalization = true
-exclude = "(ibis/_version|versioneer)\\.py"
+exclude = "(ibis/_version|versioneer)\\.py|\\.ipynb"
 
 [tool.isort]
 ensure_newline_before_comments = true


### PR DESCRIPTION
- refactor: clean topk input
- refactor: clean up argument cleaning for aggs
- refactor: clean up sort key cleaning
- refactor: just promote to a list
- refactor: promote list for agg
- refactor: check for false-y exprs instead of just None
- refactor: remove __call__ from expressions
- refactor: remove noop from analytics
- fix: fix pushdown with or test resulting from always promoting to a list
- docs: ignore ipynb when formatting code
- style: clean up test_compiler code style a bit
- test: ensure that we're not testing with an invalid expression
- fix: rename list_of to value_list_of
- style: clean up test_table.py style a bit
- test: pull out cases into param test
- test: fix error for invalid join expr
- test: raise an error when markers are empty and an error is encountered
- feat: make exprlist iterable for flattening later
- refactor: remove dead code in cross join
- refactor: move tablearrayview validation to API function
- refactor: remove constructor from WindowOp
- refactor: thread kwargs around
- fix: disambiguate Any import
- feat: add flattening list_of rule
- feat: add tuple_of rule
- feat: add enum_mapping rule
- feat: add sort_key rule
- feat: add function_of rule for validation of arguments depending on another argument
- refactor: refactor table rules
- feat: add column_from rule for validation of table columns
- feat: add column_name_from for validating existence of column names
- feat: add expr_list_of rule
- feat: move reduction validation into a rule
- feat: add non negative integer rule validation
- feat: add literal rule validation
- feat: add named_literal_expression validation rule
- feat: add rule for validating pairs of values
- refactor: stricter validation of literal expressions
- refactor: replace TableColumn constructor with rules
- refactor: give SQLQueryResult query a proper input type
- refactor: use a proper rule for data type validation
- refactor: remove unnecessary parentheses in rule expressions
- chore: CHECKPOINT
- fix: add ndarray to allowed literal types
- fix: make sure _ensure_key is callable on table nodes during sort key conversion
- fix: use reverse lookup of sort key children for deferred sort keys and strings
- test: adjust tests to accomodate reverse key lookups
- refactor: differentiate loop variables
- refactor: remove unnecessary index tracking code
- revert: bring callable expressions back
- style: format error message strings
- fix: add bytes to allowed literals
- style: sort literal instance types
- fix: add geometry literal type
- test: use set for input types to avoid irrelevant ordering test failures
- test: use set to construct isin inputs
- fix: allow computable inputs as literals
- docs: add post_process argument docstring
- refactor: add default_value property
- feat: add requires argument for constraining inputs based on existence of other arguments
- fix: add requires to aggregation
- docs: clean up Argument docstring
- style: remove redundant util reference
