### PR TITLE
swap duckdb and bigquery tabsets

### DIFF
--- a/docs/posts/backend-agnostic-arrays/index.qmd
+++ b/docs/posts/backend-agnostic-arrays/index.qmd
@@ -45,15 +45,6 @@ from ibis.interactive import *  # <1>
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq = ibis.connect("bigquery://ibis-gbq")
-bq.set_database("bigquery-public-data.imdb")  # <1>
-```
-
-1. Google provides a public BigQuery dataset for IMDB data.
-
 ## DuckDB
 
 ```{python}
@@ -69,6 +60,15 @@ ddb.create_table(  # <2>
 1. Create a table called `name_basics` in our DuckDB database using `ibis.examples` data
 2. Create a table called `title_basics` in our DuckDB database using `ibis.examples` data
 
+## BigQuery
+
+```{python}
+bq = ibis.connect("bigquery://ibis-gbq")
+bq.set_database("bigquery-public-data.imdb")  # <1>
+```
+
+1. Google provides a public BigQuery dataset for IMDB data.
+
 :::
 
 Let's pull out the `name_basics` table, which contains names and metadata about
@@ -77,18 +77,18 @@ columns we won't need:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents = bq.tables.name_basics.drop("birth_year", "death_year")
-bq_ents.order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents = ddb.tables.name_basics.drop("birth_year", "death_year")
 ddb_ents.order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents = bq.tables.name_basics.drop("birth_year", "death_year")
+bq_ents.order_by("nconst")
 ```
 
 :::
@@ -102,18 +102,18 @@ method on that column and replace the existing column:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents = bq_ents.mutate(known_for_titles=_.known_for_titles.split(","))
-bq_ents.order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents = ddb_ents.mutate(known_for_titles=_.known_for_titles.split(","))
 ddb_ents.order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents = bq_ents.mutate(known_for_titles=_.known_for_titles.split(","))
+bq_ents.order_by("nconst")
 ```
 
 :::
@@ -123,16 +123,16 @@ have more than one responsibility on a project:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents = bq_ents.mutate(primary_profession=_.primary_profession.split(","))
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents = ddb_ents.mutate(primary_profession=_.primary_profession.split(","))
+```
+
+## BigQuery
+
+```{python}
+bq_ents = bq_ents.mutate(primary_profession=_.primary_profession.split(","))
 ```
 
 :::
@@ -148,21 +148,21 @@ API on array expressions:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-(
-    bq_ents.select("primary_name", num_titles=_.known_for_titles.length())
-    .order_by(_.num_titles.desc())
-    .limit(5)
-)
-```
-
 ## DuckDB
 
 ```{python}
 (
     ddb_ents.select("primary_name", num_titles=_.known_for_titles.length())
+    .order_by(_.num_titles.desc())
+    .limit(5)
+)
+```
+
+## BigQuery
+
+```{python}
+(
+    bq_ents.select("primary_name", num_titles=_.known_for_titles.length())
     .order_by(_.num_titles.desc())
     .limit(5)
 )
@@ -178,16 +178,6 @@ We can see the position of `"actor"` or `"actress"` in `primary_profession`s:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents.primary_profession.index("actor")
-```
-
-```{python}
-bq_ents.primary_profession.index("actress")
-```
-
 ## DuckDB
 
 ```{python}
@@ -196,6 +186,16 @@ ddb_ents.primary_profession.index("actor")
 
 ```{python}
 ddb_ents.primary_profession.index("actress")
+```
+
+## BigQuery
+
+```{python}
+bq_ents.primary_profession.index("actor")
+```
+
+```{python}
+bq_ents.primary_profession.index("actress")
 ```
 
 :::
@@ -211,16 +211,6 @@ method by checking whether the positions of the strings `"actor"` or
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-actor_index = bq_ents.primary_profession.index("actor")
-actress_index = bq_ents.primary_profession.index("actress")
-
-bq_not_primarily_acting = (actor_index > 0) & (actress_index > 0)
-bq_not_primarily_acting.mean()
-```
-
 ## DuckDB
 
 ```{python}
@@ -231,22 +221,32 @@ ddb_not_primarily_acting = (actor_index > 0) & (actress_index > 0)
 ddb_not_primarily_acting.mean()
 ```
 
+## BigQuery
+
+```{python}
+actor_index = bq_ents.primary_profession.index("actor")
+actress_index = bq_ents.primary_profession.index("actress")
+
+bq_not_primarily_acting = (actor_index > 0) & (actress_index > 0)
+bq_not_primarily_acting.mean()
+```
+
 :::
 
 Who are they?
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents[bq_not_primarily_acting].order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents[ddb_not_primarily_acting].order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents[bq_not_primarily_acting].order_by("nconst")
 ```
 
 :::
@@ -259,15 +259,6 @@ We can get people who are listed as actors or actresses using `contains`:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_non_actors = bq_ents[
-    ~_.primary_profession.contains("actor") & ~_.primary_profession.contains("actress")
-]
-bq_non_actors.order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
@@ -275,6 +266,15 @@ ddb_non_actors = bq_ents[
     ~_.primary_profession.contains("actor") & ~_.primary_profession.contains("actress")
 ]
 ddb_non_actors.order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_non_actors = bq_ents[
+    ~_.primary_profession.contains("actor") & ~_.primary_profession.contains("actress")
+]
+bq_non_actors.order_by("nconst")
 ```
 
 :::
@@ -291,10 +291,10 @@ Let's see who only has "actor" in the list of their primary professions:
 
 ::: {.panel-tabset}
 
-## BigQuery
+## DuckDB
 
 ```{python}
-bq_ents.filter(
+ddb_ents.filter(
     [
         _.primary_profession.length() > 0,
         _.primary_profession.remove("actor").length() == 0,
@@ -303,10 +303,10 @@ bq_ents.filter(
 ).order_by("nconst")
 ```
 
-## DuckDB
+## BigQuery
 
 ```{python}
-ddb_ents.filter(
+bq_ents.filter(
     [
         _.primary_profession.length() > 0,
         _.primary_profession.remove("actor").length() == 0,
@@ -324,18 +324,18 @@ more than one profession listed:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents[_.primary_profession.length() > 1].mutate(
-    primary_profession=_.primary_profession[1:],
-).order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents[_.primary_profession.length() > 1].mutate(
+    primary_profession=_.primary_profession[1:],
+).order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents[_.primary_profession.length() > 1].mutate(
     primary_profession=_.primary_profession[1:],
 ).order_by("nconst")
 ```
@@ -359,10 +359,10 @@ known-for titles and sort the result:
 
 ::: {.panel-tabset}
 
-## BigQuery
+## DuckDB
 
 ```{python}
-left = bq_ents.filter(_.known_for_titles.length() > 0).limit(10_000)
+left = ddb_ents.filter(_.known_for_titles.length() > 0).limit(10_000)
 right = left.view()
 shared_titles = (
     left
@@ -380,10 +380,10 @@ shared_titles = (
 shared_titles
 ```
 
-## DuckDB
+## BigQuery
 
 ```{python}
-left = ddb_ents.filter(_.known_for_titles.length() > 0).limit(10_000)
+left = bq_ents.filter(_.known_for_titles.length() > 0).limit(10_000)
 right = left.view()
 shared_titles = (
     left
@@ -419,16 +419,16 @@ You can use it standalone on a column expression:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents.primary_profession.unnest()
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents.primary_profession.unnest()
+```
+
+## BigQuery
+
+```{python}
+bq_ents.primary_profession.unnest()
 ```
 
 :::
@@ -437,16 +437,16 @@ You can also use it in `select`/`mutate` calls to expand the table accordingly:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents.mutate(primary_profession=_.primary_profession.unnest()).order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents.mutate(primary_profession=_.primary_profession.unnest()).order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents.mutate(primary_profession=_.primary_profession.unnest()).order_by("nconst")
 ```
 
 :::
@@ -456,32 +456,6 @@ Unnesting can be useful when joining nested data.
 Here we use unnest to find people known for any of the godfather movies:
 
 ::: {.panel-tabset}
-
-## BigQuery
-
-```{python}
-basics = bq.tables.title_basics.filter(  # <1>
-    [
-        _.title_type == "movie",
-        _.original_title.lower().startswith("the godfather"),
-        _.genres.lower().contains("crime"),
-    ]
-)  # <1>
-
-bq_known_for_the_godfather = (
-    bq_ents.mutate(tconst=_.known_for_titles.unnest())  # <2>
-    .join(basics, "tconst")  # <3>
-    .select("primary_title", "primary_name")  # <4>
-    .distinct()
-    .order_by(["primary_title", "primary_name"]) # <4>
-)
-bq_known_for_the_godfather
-```
-
-1. Filter the `title_basics` data set to only the Godfather movies
-2. Unnest the `known_for_titles` array column
-3. Join with `basics` to get movie titles
-4. Ensure that each entity is only listed once and sort the results
 
 ## DuckDB
 
@@ -509,22 +483,48 @@ ddb_known_for_the_godfather
 3. Join with `basics` to get movie titles
 4. Ensure that each entity is only listed once and sort the results
 
+## BigQuery
+
+```{python}
+basics = bq.tables.title_basics.filter(  # <1>
+    [
+        _.title_type == "movie",
+        _.original_title.lower().startswith("the godfather"),
+        _.genres.lower().contains("crime"),
+    ]
+)  # <1>
+
+bq_known_for_the_godfather = (
+    bq_ents.mutate(tconst=_.known_for_titles.unnest())  # <2>
+    .join(basics, "tconst")  # <3>
+    .select("primary_title", "primary_name")  # <4>
+    .distinct()
+    .order_by(["primary_title", "primary_name"]) # <4>
+)
+bq_known_for_the_godfather
+```
+
+1. Filter the `title_basics` data set to only the Godfather movies
+2. Unnest the `known_for_titles` array column
+3. Join with `basics` to get movie titles
+4. Ensure that each entity is only listed once and sort the results
+
 :::
 
 Let's summarize by showing how many people are known for each Godfather movie:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_known_for_the_godfather.primary_title.value_counts()
-```
-
 ## DuckDB
 
 ```{python}
 ddb_known_for_the_godfather.primary_title.value_counts()
+```
+
+## BigQuery
+
+```{python}
+bq_known_for_the_godfather.primary_title.value_counts()
 ```
 
 :::
@@ -543,10 +543,10 @@ Let's show all people who are neither editors nor actors:
 
 ::: {.panel-tabset}
 
-## BigQuery
+## DuckDB
 
 ```{python}
-bq_ents.mutate(
+ddb_ents.mutate(
     primary_profession=_.primary_profession.filter(  # <1>
         lambda pp: ~pp.isin(("actor", "actress", "editor"))
     )
@@ -556,10 +556,10 @@ bq_ents.mutate(
 1. This `filter` call is applied to each array element
 2. This `filter` call is applied to the table
 
-## DuckDB
+## BigQuery
 
 ```{python}
-ddb_ents.mutate(
+bq_ents.mutate(
     primary_profession=_.primary_profession.filter(  # <1>
         lambda pp: ~pp.isin(("actor", "actress", "editor"))
     )
@@ -582,18 +582,18 @@ Let's normalize the case of primary_profession to upper case:
 
 ::: {.panel-tabset}
 
-## BigQuery
-
-```{python}
-bq_ents.mutate(
-    primary_profession=_.primary_profession.map(lambda pp: pp.upper())
-).filter(_.primary_profession.length() > 0).order_by("nconst")
-```
-
 ## DuckDB
 
 ```{python}
 ddb_ents.mutate(
+    primary_profession=_.primary_profession.map(lambda pp: pp.upper())
+).filter(_.primary_profession.length() > 0).order_by("nconst")
+```
+
+## BigQuery
+
+```{python}
+bq_ents.mutate(
     primary_profession=_.primary_profession.map(lambda pp: pp.upper())
 ).filter(_.primary_profession.length() > 0).order_by("nconst")
 ```


### PR DESCRIPTION
most users will start local and scale up (DuckDB), then move to a cloud data platform and scale out (BigQuery) -- accordingly moves DuckDB on the left and BigQuery on the right in the tabsets, which I mildly prefer. feel free to reejct 